### PR TITLE
feat: タスク読み取りAPI（GET）を実装 (close #3)

### DIFF
--- a/backend/src/main/java/com/taskmanagement/backend/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/backend/controller/BoardController.java
@@ -1,0 +1,30 @@
+package com.taskmanagement.backend.controller;
+
+import com.taskmanagement.backend.dto.BoardResponse;
+import com.taskmanagement.backend.dto.BoardSummaryResponse;
+import com.taskmanagement.backend.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @GetMapping
+    public List<BoardSummaryResponse> getAll() {
+        return boardService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public BoardResponse getById(@PathVariable Long id) {
+        return boardService.findById(id);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/controller/CardController.java
+++ b/backend/src/main/java/com/taskmanagement/backend/controller/CardController.java
@@ -1,0 +1,29 @@
+package com.taskmanagement.backend.controller;
+
+import com.taskmanagement.backend.dto.CardResponse;
+import com.taskmanagement.backend.service.CardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CardController {
+
+    private final CardService cardService;
+
+    @GetMapping("/lists/{listId}/cards")
+    public List<CardResponse> getByListId(@PathVariable Long listId) {
+        return cardService.findByListId(listId);
+    }
+
+    @GetMapping("/cards/{id}")
+    public CardResponse getById(@PathVariable Long id) {
+        return cardService.findById(id);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/dto/BoardResponse.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/BoardResponse.java
@@ -1,0 +1,27 @@
+package com.taskmanagement.backend.dto;
+
+import com.taskmanagement.backend.entity.Board;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class BoardResponse {
+
+    private final Long id;
+    private final String title;
+    private final Integer position;
+    private final List<ListResponse> lists;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public BoardResponse(Board board) {
+        this.id = board.getId();
+        this.title = board.getTitle();
+        this.position = board.getPosition();
+        this.lists = board.getLists().stream().map(ListResponse::new).toList();
+        this.createdAt = board.getCreatedAt();
+        this.updatedAt = board.getUpdatedAt();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/dto/BoardSummaryResponse.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/BoardSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.taskmanagement.backend.dto;
+
+import com.taskmanagement.backend.entity.Board;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class BoardSummaryResponse {
+
+    private final Long id;
+    private final String title;
+    private final Integer position;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public BoardSummaryResponse(Board board) {
+        this.id = board.getId();
+        this.title = board.getTitle();
+        this.position = board.getPosition();
+        this.createdAt = board.getCreatedAt();
+        this.updatedAt = board.getUpdatedAt();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/dto/CardResponse.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/CardResponse.java
@@ -1,0 +1,28 @@
+package com.taskmanagement.backend.dto;
+
+import com.taskmanagement.backend.entity.Card;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CardResponse {
+
+    private final Long id;
+    private final Long listId;
+    private final String title;
+    private final String description;
+    private final Integer position;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public CardResponse(Card card) {
+        this.id = card.getId();
+        this.listId = card.getTaskList().getId();
+        this.title = card.getTitle();
+        this.description = card.getDescription();
+        this.position = card.getPosition();
+        this.createdAt = card.getCreatedAt();
+        this.updatedAt = card.getUpdatedAt();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/dto/ListResponse.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/ListResponse.java
@@ -1,0 +1,29 @@
+package com.taskmanagement.backend.dto;
+
+import com.taskmanagement.backend.entity.TaskList;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class ListResponse {
+
+    private final Long id;
+    private final Long boardId;
+    private final String title;
+    private final Integer position;
+    private final List<CardResponse> cards;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public ListResponse(TaskList list) {
+        this.id = list.getId();
+        this.boardId = list.getBoard().getId();
+        this.title = list.getTitle();
+        this.position = list.getPosition();
+        this.cards = list.getCards().stream().map(CardResponse::new).toList();
+        this.createdAt = list.getCreatedAt();
+        this.updatedAt = list.getUpdatedAt();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/service/BoardService.java
+++ b/backend/src/main/java/com/taskmanagement/backend/service/BoardService.java
@@ -1,0 +1,33 @@
+package com.taskmanagement.backend.service;
+
+import com.taskmanagement.backend.dto.BoardResponse;
+import com.taskmanagement.backend.dto.BoardSummaryResponse;
+import com.taskmanagement.backend.entity.Board;
+import com.taskmanagement.backend.repository.BoardRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    public List<BoardSummaryResponse> findAll() {
+        return boardRepository.findAllByOrderByPositionAsc()
+                .stream()
+                .map(BoardSummaryResponse::new)
+                .toList();
+    }
+
+    public BoardResponse findById(Long id) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Board not found: " + id));
+        return new BoardResponse(board);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/backend/service/CardService.java
+++ b/backend/src/main/java/com/taskmanagement/backend/service/CardService.java
@@ -1,0 +1,32 @@
+package com.taskmanagement.backend.service;
+
+import com.taskmanagement.backend.dto.CardResponse;
+import com.taskmanagement.backend.entity.Card;
+import com.taskmanagement.backend.repository.CardRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CardService {
+
+    private final CardRepository cardRepository;
+
+    public List<CardResponse> findByListId(Long listId) {
+        return cardRepository.findByTaskListIdOrderByPositionAsc(listId)
+                .stream()
+                .map(CardResponse::new)
+                .toList();
+    }
+
+    public CardResponse findById(Long id) {
+        Card card = cardRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Card not found: " + id));
+        return new CardResponse(card);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,9 +1,22 @@
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:taskmanagement}
+    username: ${DB_USER:taskuser}
+    password: ${DB_PASSWORD:taskpass}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 server:
   port: 8080

--- a/backend/src/main/resources/db/migration/V2__seed_data.sql
+++ b/backend/src/main/resources/db/migration/V2__seed_data.sql
@@ -1,0 +1,40 @@
+-- テストデータ投入
+-- Board
+INSERT INTO boards (title, position) VALUES
+    ('開発タスク', 0),
+    ('学習メモ',   1);
+
+-- List（Board 1: 開発タスク）
+INSERT INTO lists (board_id, title, position) VALUES
+    (1, 'TODO',      0),
+    (1, '進行中',    1),
+    (1, '完了',      2);
+
+-- List（Board 2: 学習メモ）
+INSERT INTO lists (board_id, title, position) VALUES
+    (2, 'インプット',  0),
+    (2, 'アウトプット', 1);
+
+-- Card（List 1: TODO）
+INSERT INTO cards (list_id, title, description, position) VALUES
+    (1, 'ボード一覧APIの実装',      'GET /api/boards を実装する',            0),
+    (1, 'カード移動APIの実装',      'PATCH /api/cards/{id}/move を実装する', 1),
+    (1, 'フロントエンド環境構築',    'Vite + React + TypeScript のセットアップ', 2);
+
+-- Card（List 2: 進行中）
+INSERT INTO cards (list_id, title, description, position) VALUES
+    (2, 'READ APIの実装',  'GET エンドポイントを実装中', 0);
+
+-- Card（List 3: 完了）
+INSERT INTO cards (list_id, title, description, position) VALUES
+    (3, 'Spring Boot 雛形作成',  'Spring Initializr でプロジェクトを生成した', 0),
+    (3, 'DB設計',                 'boards / lists / cards テーブルを定義した',  1);
+
+-- Card（List 4: インプット）
+INSERT INTO cards (list_id, title, description, position) VALUES
+    (4, 'Spring Data JPA 学習', '@OneToMany / @ManyToOne の使い方を学んだ', 0),
+    (4, 'Flyway 学習',          'マイグレーションファイルの命名規則を学んだ', 1);
+
+-- Card（List 5: アウトプット）
+INSERT INTO cards (list_id, title, description, position) VALUES
+    (5, 'Qiita 記事執筆', 'Spring Boot + PostgreSQL の環境構築手順をまとめる', 0);


### PR DESCRIPTION
## 関連 Issue

close #3

---

## 変更内容

- application.yml の DB 接続設定を復元
- DTO クラスを追加（BoardResponse / BoardSummaryResponse / ListResponse / CardResponse）
- Service クラスを追加（BoardService / CardService）
- Controller を追加（BoardController / CardController）
- Flyway V2 テストデータを追加（2ボード / 5リスト / 9カード）

## エンドポイント一覧
| メソッド | パス | 説明 |
|---------|------|------|
| GET | /api/boards | 全ボード一覧 |
| GET | /api/boards/{id} | ボード詳細（リスト・カード含む） |
| GET | /api/lists/{listId}/cards | リスト内カード一覧 |
| GET | /api/cards/{id} | カード詳細 |

---

## 変更の種類

- [x] feat（新機能）

---

## 動作確認

- [x] PostgreSQL 起動済み・テストデータ投入済み
- [x] 各エンドポイントで curl によりデータ取得を確認
- [x] 既存の /api/health への影響なし