### PR TITLE
feat: ボード一覧・詳細画面（カンバンボード）を実装 (close #6, close #7)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,121 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import './App.css'
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import BoardListPage from './pages/BoardListPage';
+import BoardDetailPage from './pages/BoardDetailPage';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
-      </section>
-
-      <div className="ticks"></div>
-
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
-  )
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<BoardListPage />} />
+        <Route path="/boards/:id" element={<BoardDetailPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
-
-export default App

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -1,0 +1,8 @@
+import client from './client';
+import type { Board, BoardSummary } from '../types';
+
+export const fetchBoards = (): Promise<BoardSummary[]> =>
+  client.get<BoardSummary[]>('/boards').then((r) => r.data);
+
+export const fetchBoard = (id: number): Promise<Board> =>
+  client.get<Board>(`/boards/${id}`).then((r) => r.data);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: '/api',
+});
+
+export default client;

--- a/frontend/src/components/BoardCard.tsx
+++ b/frontend/src/components/BoardCard.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import type { BoardSummary } from '../types';
+
+type Props = {
+  board: BoardSummary;
+};
+
+export default function BoardCard({ board }: Props) {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      onClick={() => navigate(`/boards/${board.id}`)}
+      className="w-full text-left bg-white rounded-xl shadow hover:shadow-md border border-gray-200 p-5 transition-shadow cursor-pointer"
+    >
+      <h2 className="text-lg font-semibold text-gray-800 truncate">{board.title}</h2>
+      <p className="mt-1 text-sm text-gray-400">
+        {new Date(board.updatedAt).toLocaleDateString('ja-JP')} 更新
+      </p>
+    </button>
+  );
+}

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -1,0 +1,16 @@
+import type { Card } from '../types';
+
+type Props = {
+  card: Card;
+};
+
+export default function KanbanCard({ card }: Props) {
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3">
+      <p className="text-sm font-medium text-gray-800">{card.title}</p>
+      {card.description && (
+        <p className="mt-1 text-xs text-gray-500 line-clamp-2">{card.description}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,0 +1,19 @@
+import type { TaskList } from '../types';
+import KanbanCard from './KanbanCard';
+
+type Props = {
+  list: TaskList;
+};
+
+export default function KanbanColumn({ list }: Props) {
+  return (
+    <div className="flex-shrink-0 w-72 bg-gray-100 rounded-xl p-3">
+      <h3 className="text-sm font-semibold text-gray-700 mb-3 px-1">{list.title}</h3>
+      <div className="flex flex-col gap-2 min-h-8">
+        {list.cards.map((card) => (
+          <KanbanCard key={card.id} card={card} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/BoardDetailPage.tsx
+++ b/frontend/src/pages/BoardDetailPage.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useBoardStore } from '../store/boardStore';
+import KanbanColumn from '../components/KanbanColumn';
+
+export default function BoardDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { selectedBoard, isLoading, error, fetchBoard } = useBoardStore();
+
+  useEffect(() => {
+    if (id) fetchBoard(Number(id));
+  }, [id, fetchBoard]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-red-500">{error}</p>
+      </div>
+    );
+  }
+
+  if (!selectedBoard) return null;
+
+  return (
+    <div className="min-h-screen bg-blue-50 flex flex-col">
+      <header className="bg-blue-600 text-white px-6 py-4 flex items-center gap-4">
+        <button
+          onClick={() => navigate('/')}
+          className="text-sm bg-blue-500 hover:bg-blue-400 px-3 py-1 rounded transition-colors"
+        >
+          ← 一覧に戻る
+        </button>
+        <h1 className="text-lg font-bold">{selectedBoard.title}</h1>
+      </header>
+
+      <main className="flex-1 overflow-x-auto p-6">
+        <div className="flex gap-4 items-start">
+          {selectedBoard.lists.map((list) => (
+            <KanbanColumn key={list.id} list={list} />
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/BoardListPage.tsx
+++ b/frontend/src/pages/BoardListPage.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useBoardStore } from '../store/boardStore';
+import BoardCard from '../components/BoardCard';
+
+export default function BoardListPage() {
+  const { boards, isLoading, error, fetchBoards } = useBoardStore();
+
+  useEffect(() => {
+    fetchBoards();
+  }, [fetchBoards]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-red-500">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <h1 className="text-2xl font-bold text-gray-800 mb-6">ボード一覧</h1>
+      {boards.length === 0 ? (
+        <p className="text-gray-400">ボードがありません</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {boards.map((board) => (
+            <BoardCard key={board.id} board={board} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/store/boardStore.ts
+++ b/frontend/src/store/boardStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { fetchBoards as apiFetchBoards, fetchBoard as apiFetchBoard } from '../api/boards';
+import type { Board, BoardSummary } from '../types';
+
+type BoardStore = {
+  boards: BoardSummary[];
+  selectedBoard: Board | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchBoards: () => Promise<void>;
+  fetchBoard: (id: number) => Promise<void>;
+};
+
+export const useBoardStore = create<BoardStore>((set) => ({
+  boards: [],
+  selectedBoard: null,
+  isLoading: false,
+  error: null,
+
+  fetchBoards: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const boards = await apiFetchBoards();
+      set({ boards, isLoading: false });
+    } catch {
+      set({ error: 'ボードの取得に失敗しました', isLoading: false });
+    }
+  },
+
+  fetchBoard: async (id: number) => {
+    set({ isLoading: true, error: null, selectedBoard: null });
+    try {
+      const board = await apiFetchBoard(id);
+      set({ selectedBoard: board, isLoading: false });
+    } catch {
+      set({ error: 'ボードの取得に失敗しました', isLoading: false });
+    }
+  },
+}));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,36 @@
+export type BoardSummary = {
+  id: number;
+  title: string;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Card = {
+  id: number;
+  listId: number;
+  title: string;
+  description: string | null;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TaskList = {
+  id: number;
+  boardId: number;
+  title: string;
+  position: number;
+  cards: Card[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Board = {
+  id: number;
+  title: string;
+  position: number;
+  lists: TaskList[];
+  createdAt: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
## Summary
- 型定義（BoardSummary, Board, TaskList, Card）を追加
- axios ベースの API クライアントを実装（/api プレフィックス）
- Zustand ストアでボード一覧・詳細の状態管理を実装
- ボード一覧画面（BoardListPage）: GET /api/boards の結果をグリッド表示
- ボード詳細画面（BoardDetailPage）: GET /api/boards/{id} の結果をカンバン形式で表示
- React Router で `/` → 一覧、`/boards/:id` → 詳細 のルーティングを設定

## Test plan
- [ ] `http://localhost:5173` でボード一覧が表示される（シードデータ2件）
- [ ] ボードカードをクリックするとカンバンボード画面に遷移する
- [ ] カンバン列（TODO/進行中/完了など）とカードが正しく表示される
- [ ] 「一覧に戻る」ボタンで一覧画面に戻れる
- [ ] ローディング・エラー時の UI が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)