### PR TITLE
feat: ボード・リスト・カードの登録処理を実装 (close #12)

### DIFF
--- a/backend/src/main/java/com/taskmanagement/backend/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/backend/controller/BoardController.java
@@ -1,13 +1,16 @@
 package com.taskmanagement.backend.controller;
 
+import com.taskmanagement.backend.dto.BoardRequest;
 import com.taskmanagement.backend.dto.BoardResponse;
 import com.taskmanagement.backend.dto.BoardSummaryResponse;
+import com.taskmanagement.backend.dto.ListRequest;
+import com.taskmanagement.backend.dto.ListResponse;
 import com.taskmanagement.backend.service.BoardService;
+import com.taskmanagement.backend.service.TaskListService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,6 +20,7 @@ import java.util.List;
 public class BoardController {
 
     private final BoardService boardService;
+    private final TaskListService taskListService;
 
     @GetMapping
     public List<BoardSummaryResponse> getAll() {
@@ -26,5 +30,17 @@ public class BoardController {
     @GetMapping("/{id}")
     public BoardResponse getById(@PathVariable Long id) {
         return boardService.findById(id);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public BoardSummaryResponse create(@Valid @RequestBody BoardRequest request) {
+        return boardService.create(request);
+    }
+
+    @PostMapping("/{boardId}/lists")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ListResponse createList(@PathVariable Long boardId, @Valid @RequestBody ListRequest request) {
+        return taskListService.create(boardId, request);
     }
 }

--- a/backend/src/main/java/com/taskmanagement/backend/controller/CardController.java
+++ b/backend/src/main/java/com/taskmanagement/backend/controller/CardController.java
@@ -1,12 +1,12 @@
 package com.taskmanagement.backend.controller;
 
+import com.taskmanagement.backend.dto.CardRequest;
 import com.taskmanagement.backend.dto.CardResponse;
 import com.taskmanagement.backend.service.CardService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,5 +25,11 @@ public class CardController {
     @GetMapping("/cards/{id}")
     public CardResponse getById(@PathVariable Long id) {
         return cardService.findById(id);
+    }
+
+    @PostMapping("/lists/{listId}/cards")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CardResponse create(@PathVariable Long listId, @Valid @RequestBody CardRequest request) {
+        return cardService.create(listId, request);
     }
 }

--- a/backend/src/main/java/com/taskmanagement/backend/dto/BoardRequest.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/BoardRequest.java
@@ -1,0 +1,7 @@
+package com.taskmanagement.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BoardRequest(
+        @NotBlank String title
+) {}

--- a/backend/src/main/java/com/taskmanagement/backend/dto/CardRequest.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/CardRequest.java
@@ -1,0 +1,8 @@
+package com.taskmanagement.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CardRequest(
+        @NotBlank String title,
+        String description
+) {}

--- a/backend/src/main/java/com/taskmanagement/backend/dto/ListRequest.java
+++ b/backend/src/main/java/com/taskmanagement/backend/dto/ListRequest.java
@@ -1,0 +1,7 @@
+package com.taskmanagement.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ListRequest(
+        @NotBlank String title
+) {}

--- a/backend/src/main/java/com/taskmanagement/backend/service/BoardService.java
+++ b/backend/src/main/java/com/taskmanagement/backend/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.taskmanagement.backend.service;
 
+import com.taskmanagement.backend.dto.BoardRequest;
 import com.taskmanagement.backend.dto.BoardResponse;
 import com.taskmanagement.backend.dto.BoardSummaryResponse;
 import com.taskmanagement.backend.entity.Board;
@@ -29,5 +30,14 @@ public class BoardService {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Board not found: " + id));
         return new BoardResponse(board);
+    }
+
+    @Transactional
+    public BoardSummaryResponse create(BoardRequest request) {
+        int nextPosition = boardRepository.findAllByOrderByPositionAsc().size();
+        Board board = new Board();
+        board.setTitle(request.title());
+        board.setPosition(nextPosition);
+        return new BoardSummaryResponse(boardRepository.save(board));
     }
 }

--- a/backend/src/main/java/com/taskmanagement/backend/service/CardService.java
+++ b/backend/src/main/java/com/taskmanagement/backend/service/CardService.java
@@ -1,8 +1,11 @@
 package com.taskmanagement.backend.service;
 
+import com.taskmanagement.backend.dto.CardRequest;
 import com.taskmanagement.backend.dto.CardResponse;
 import com.taskmanagement.backend.entity.Card;
+import com.taskmanagement.backend.entity.TaskList;
 import com.taskmanagement.backend.repository.CardRepository;
+import com.taskmanagement.backend.repository.TaskListRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import java.util.List;
 public class CardService {
 
     private final CardRepository cardRepository;
+    private final TaskListRepository taskListRepository;
 
     public List<CardResponse> findByListId(Long listId) {
         return cardRepository.findByTaskListIdOrderByPositionAsc(listId)
@@ -28,5 +32,18 @@ public class CardService {
         Card card = cardRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Card not found: " + id));
         return new CardResponse(card);
+    }
+
+    @Transactional
+    public CardResponse create(Long listId, CardRequest request) {
+        TaskList taskList = taskListRepository.findById(listId)
+                .orElseThrow(() -> new EntityNotFoundException("List not found: " + listId));
+        int nextPosition = cardRepository.findByTaskListIdOrderByPositionAsc(listId).size();
+        Card card = new Card();
+        card.setTaskList(taskList);
+        card.setTitle(request.title());
+        card.setDescription(request.description());
+        card.setPosition(nextPosition);
+        return new CardResponse(cardRepository.save(card));
     }
 }

--- a/backend/src/main/java/com/taskmanagement/backend/service/TaskListService.java
+++ b/backend/src/main/java/com/taskmanagement/backend/service/TaskListService.java
@@ -1,0 +1,32 @@
+package com.taskmanagement.backend.service;
+
+import com.taskmanagement.backend.dto.ListRequest;
+import com.taskmanagement.backend.dto.ListResponse;
+import com.taskmanagement.backend.entity.Board;
+import com.taskmanagement.backend.entity.TaskList;
+import com.taskmanagement.backend.repository.BoardRepository;
+import com.taskmanagement.backend.repository.TaskListRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TaskListService {
+
+    private final TaskListRepository taskListRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public ListResponse create(Long boardId, ListRequest request) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new EntityNotFoundException("Board not found: " + boardId));
+        int nextPosition = taskListRepository.findByBoardIdOrderByPositionAsc(boardId).size();
+        TaskList list = new TaskList();
+        list.setBoard(board);
+        list.setTitle(request.title());
+        list.setPosition(nextPosition);
+        return new ListResponse(taskListRepository.save(list));
+    }
+}

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -1,8 +1,17 @@
 import client from './client';
-import type { Board, BoardSummary } from '../types';
+import type { Board, BoardSummary, TaskList, Card } from '../types';
 
 export const fetchBoards = (): Promise<BoardSummary[]> =>
   client.get<BoardSummary[]>('/boards').then((r) => r.data);
 
 export const fetchBoard = (id: number): Promise<Board> =>
   client.get<Board>(`/boards/${id}`).then((r) => r.data);
+
+export const createBoard = (title: string): Promise<BoardSummary> =>
+  client.post<BoardSummary>('/boards', { title }).then((r) => r.data);
+
+export const createList = (boardId: number, title: string): Promise<TaskList> =>
+  client.post<TaskList>(`/boards/${boardId}/lists`, { title }).then((r) => r.data);
+
+export const createCard = (listId: number, title: string, description?: string): Promise<Card> =>
+  client.post<Card>(`/lists/${listId}/cards`, { title, description }).then((r) => r.data);

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,11 +1,31 @@
+import { useState } from 'react';
 import type { TaskList } from '../types';
 import KanbanCard from './KanbanCard';
+import { useBoardStore } from '../store/boardStore';
 
 type Props = {
   list: TaskList;
 };
 
 export default function KanbanColumn({ list }: Props) {
+  const { createCard } = useBoardStore();
+  const [adding, setAdding] = useState(false);
+  const [title, setTitle] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSaving(true);
+    try {
+      await createCard(list.id, title.trim());
+      setTitle('');
+      setAdding(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className="flex-shrink-0 w-72 bg-gray-100 rounded-xl p-3">
       <h3 className="text-sm font-semibold text-gray-700 mb-3 px-1">{list.title}</h3>
@@ -14,6 +34,42 @@ export default function KanbanColumn({ list }: Props) {
           <KanbanCard key={card.id} card={card} />
         ))}
       </div>
+
+      {adding ? (
+        <form onSubmit={handleAdd} className="mt-2">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="カードのタイトル"
+            className="w-full border border-gray-300 rounded-lg px-2 py-1.5 text-sm mb-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving || !title.trim()}
+              className="bg-blue-600 text-white px-3 py-1 rounded text-xs hover:bg-blue-500 disabled:opacity-50"
+            >
+              {saving ? '追加中...' : 'カードを追加'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setAdding(false); setTitle(''); }}
+              className="text-gray-500 hover:text-gray-700 text-xs px-2"
+            >
+              キャンセル
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button
+          onClick={() => setAdding(true)}
+          className="mt-2 w-full text-left text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-200 rounded-lg px-2 py-1.5 transition-colors"
+        >
+          + カードを追加
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/BoardDetailPage.tsx
+++ b/frontend/src/pages/BoardDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useBoardStore } from '../store/boardStore';
 import KanbanColumn from '../components/KanbanColumn';
@@ -6,11 +6,27 @@ import KanbanColumn from '../components/KanbanColumn';
 export default function BoardDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { selectedBoard, isLoading, error, fetchBoard } = useBoardStore();
+  const { selectedBoard, isLoading, error, fetchBoard, createList } = useBoardStore();
+  const [addingList, setAddingList] = useState(false);
+  const [listTitle, setListTitle] = useState('');
+  const [savingList, setSavingList] = useState(false);
 
   useEffect(() => {
     if (id) fetchBoard(Number(id));
   }, [id, fetchBoard]);
+
+  const handleAddList = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedBoard || !listTitle.trim()) return;
+    setSavingList(true);
+    try {
+      await createList(selectedBoard.id, listTitle.trim());
+      setListTitle('');
+      setAddingList(false);
+    } finally {
+      setSavingList(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -47,6 +63,45 @@ export default function BoardDetailPage() {
           {selectedBoard.lists.map((list) => (
             <KanbanColumn key={list.id} list={list} />
           ))}
+
+          {addingList ? (
+            <form
+              onSubmit={handleAddList}
+              className="flex-shrink-0 w-72 bg-gray-100 rounded-xl p-3"
+            >
+              <input
+                type="text"
+                value={listTitle}
+                onChange={(e) => setListTitle(e.target.value)}
+                placeholder="リストのタイトル"
+                className="w-full border border-gray-300 rounded-lg px-2 py-1.5 text-sm mb-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                autoFocus
+              />
+              <div className="flex gap-2">
+                <button
+                  type="submit"
+                  disabled={savingList || !listTitle.trim()}
+                  className="bg-blue-600 text-white px-3 py-1 rounded text-xs hover:bg-blue-500 disabled:opacity-50"
+                >
+                  {savingList ? '追加中...' : 'リストを追加'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setAddingList(false); setListTitle(''); }}
+                  className="text-gray-500 hover:text-gray-700 text-xs px-2"
+                >
+                  キャンセル
+                </button>
+              </div>
+            </form>
+          ) : (
+            <button
+              onClick={() => setAddingList(true)}
+              className="flex-shrink-0 w-72 bg-white/60 hover:bg-white/80 text-gray-600 hover:text-gray-800 rounded-xl p-3 text-sm font-medium transition-colors text-left"
+            >
+              + リストを追加
+            </button>
+          )}
         </div>
       </main>
     </div>

--- a/frontend/src/pages/BoardListPage.tsx
+++ b/frontend/src/pages/BoardListPage.tsx
@@ -1,13 +1,29 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useBoardStore } from '../store/boardStore';
 import BoardCard from '../components/BoardCard';
 
 export default function BoardListPage() {
-  const { boards, isLoading, error, fetchBoards } = useBoardStore();
+  const { boards, isLoading, error, fetchBoards, createBoard } = useBoardStore();
+  const [showModal, setShowModal] = useState(false);
+  const [title, setTitle] = useState('');
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     fetchBoards();
   }, [fetchBoards]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setCreating(true);
+    try {
+      await createBoard(title.trim());
+      setTitle('');
+      setShowModal(false);
+    } finally {
+      setCreating(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -27,7 +43,16 @@ export default function BoardListPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 p-8">
-      <h1 className="text-2xl font-bold text-gray-800 mb-6">ボード一覧</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-800">ボード一覧</h1>
+        <button
+          onClick={() => setShowModal(true)}
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-500 transition-colors text-sm font-medium"
+        >
+          + ボードを作成
+        </button>
+      </div>
+
       {boards.length === 0 ? (
         <p className="text-gray-400">ボードがありません</p>
       ) : (
@@ -35,6 +60,40 @@ export default function BoardListPage() {
           {boards.map((board) => (
             <BoardCard key={board.id} board={board} />
           ))}
+        </div>
+      )}
+
+      {showModal && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm">
+            <h2 className="text-lg font-bold text-gray-800 mb-4">新しいボードを作成</h2>
+            <form onSubmit={handleCreate}>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="ボードのタイトル"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                autoFocus
+              />
+              <div className="flex gap-2 justify-end">
+                <button
+                  type="button"
+                  onClick={() => { setShowModal(false); setTitle(''); }}
+                  className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="submit"
+                  disabled={creating || !title.trim()}
+                  className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-500 disabled:opacity-50 transition-colors"
+                >
+                  {creating ? '作成中...' : '作成'}
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/store/boardStore.ts
+++ b/frontend/src/store/boardStore.ts
@@ -1,6 +1,12 @@
 import { create } from 'zustand';
-import { fetchBoards as apiFetchBoards, fetchBoard as apiFetchBoard } from '../api/boards';
-import type { Board, BoardSummary } from '../types';
+import {
+  fetchBoards as apiFetchBoards,
+  fetchBoard as apiFetchBoard,
+  createBoard as apiCreateBoard,
+  createList as apiCreateList,
+  createCard as apiCreateCard,
+} from '../api/boards';
+import type { Board, BoardSummary, TaskList, Card } from '../types';
 
 type BoardStore = {
   boards: BoardSummary[];
@@ -9,9 +15,12 @@ type BoardStore = {
   error: string | null;
   fetchBoards: () => Promise<void>;
   fetchBoard: (id: number) => Promise<void>;
+  createBoard: (title: string) => Promise<void>;
+  createList: (boardId: number, title: string) => Promise<TaskList>;
+  createCard: (listId: number, title: string, description?: string) => Promise<Card>;
 };
 
-export const useBoardStore = create<BoardStore>((set) => ({
+export const useBoardStore = create<BoardStore>((set, get) => ({
   boards: [],
   selectedBoard: null,
   isLoading: false,
@@ -35,5 +44,40 @@ export const useBoardStore = create<BoardStore>((set) => ({
     } catch {
       set({ error: 'ボードの取得に失敗しました', isLoading: false });
     }
+  },
+
+  createBoard: async (title: string) => {
+    const board = await apiCreateBoard(title);
+    set((state) => ({ boards: [...state.boards, board] }));
+  },
+
+  createList: async (boardId: number, title: string) => {
+    const list = await apiCreateList(boardId, title);
+    set((state) => {
+      if (!state.selectedBoard || state.selectedBoard.id !== boardId) return state;
+      return {
+        selectedBoard: {
+          ...state.selectedBoard,
+          lists: [...state.selectedBoard.lists, list],
+        },
+      };
+    });
+    return list;
+  },
+
+  createCard: async (listId: number, title: string, description?: string) => {
+    const card = await apiCreateCard(listId, title, description);
+    set((state) => {
+      if (!state.selectedBoard) return state;
+      return {
+        selectedBoard: {
+          ...state.selectedBoard,
+          lists: state.selectedBoard.lists.map((l) =>
+            l.id === listId ? { ...l, cards: [...l.cards, card] } : l
+          ),
+        },
+      };
+    });
+    return card;
   },
 }));


### PR DESCRIPTION
## 概要
ボード・リスト・カードの新規作成機能を実装しました。

## 変更内容

### バックエンド
- `POST /api/boards` — ボード作成
- `POST /api/boards/{boardId}/lists` — リスト作成
- `POST /api/lists/{listId}/cards` — カード作成
- リクエスト DTO（BoardRequest, ListRequest, CardRequest）追加
- `TaskListService` を新規作成
- position は既存レコード数を末尾に自動設定

### フロントエンド
- ボード一覧画面に「ボードを作成」ボタン＋モーダルを追加
- ボード詳細画面（Kanban）に「リストを追加」フォームを追加
- 各リスト列に「カードを追加」インラインフォームを追加
- Zustand ストアに `createBoard` / `createList` / `createCard` アクションを追加

## 動作確認
- [x] `POST /api/boards` でボード作成 → DB に保存を確認
- [x] `POST /api/boards/{id}/lists` でリスト作成 → DB に保存を確認
- [x] `POST /api/lists/{id}/cards` でカード作成 → DB に保存を確認
- [x] フロントエンドから各登録操作が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)